### PR TITLE
Normalize indentation of react-native in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,9 +116,9 @@
         "stream": "stream-browserify",
         "zlib": "browserify-zlib"
     },
-	"react-native": {
-		"./build/crypto-hashes.js": "./build/crypto-hashes.native.js"
-	},
+    "react-native": {
+        "./build/crypto-hashes.js": "./build/crypto-hashes.native.js"
+    },
     "keywords": [
         "bitcoinjs",
         "bitcoin",


### PR DESCRIPTION
Adjust whitespace/indentation for the "react-native" field in package.json to match surrounding properties. This is a non-functional formatting change (no code or dependency changes).

## Description
<!-- Brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD changes
- [ ] Dependencies update

## Checklist

### Build & Tests
- [ ] `npm install` completes without errors
- [ ] `npm test` passes all tests
- [ ] `npm run browserBuild` completes without errors (if applicable)

### Code Quality
- [ ] Code follows the project's coding standards
- [ ] No new compiler/linter warnings introduced
- [ ] Error handling is appropriate
- [ ] TypeScript types are properly defined

### Documentation
- [ ] Code comments added for complex logic
- [ ] Public APIs are documented
- [ ] README updated (if applicable)

### Security
- [ ] No sensitive data (keys, credentials) committed
- [ ] No new security vulnerabilities introduced
- [ ] Cryptographic operations reviewed (if applicable)

### Bitcoin Specific
- [ ] Transaction serialization/deserialization is correct
- [ ] Script operations are properly validated
- [ ] Network parameters are handled correctly
- [ ] PSBT operations maintain compatibility

## Testing
<!-- Describe how you tested these changes -->

## Related Issues
<!-- Link any related issues: Fixes #123, Relates to #456 -->

---
By submitting this PR, I confirm that my contribution is made under the terms of the project's license.
